### PR TITLE
Add termcolor import fallback

### DIFF
--- a/nospc.py
+++ b/nospc.py
@@ -4,7 +4,11 @@ import os
 import re
 import sys
 import argparse
-from termcolor import colored
+try:
+    from termcolor import colored
+except Exception:  # pragma: no cover - fallback if termcolor is missing
+    def colored(text, *_, **__):
+        return text
 import unicodedata
 
 all_whitespace_pattern = re.compile(r'\s')


### PR DESCRIPTION
## Summary
- provide a fallback coloured() function when `termcolor` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cdcebc58832588c9a5ce737841cd