### PR TITLE
Limit import fallback

### DIFF
--- a/nospc.py
+++ b/nospc.py
@@ -6,7 +6,7 @@ import sys
 import argparse
 try:
     from termcolor import colored
-except Exception:  # pragma: no cover - fallback if termcolor is missing
+except ImportError:  # pragma: no cover - fallback if termcolor is missing
     def colored(text, *_, **__):
         return text
 import unicodedata


### PR DESCRIPTION
## Summary
- narrow `nospc` colored import error handling to `ImportError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411a64e2e8832587ec2a3483be94f3